### PR TITLE
Display listener statistics inside the app

### DIFF
--- a/functions/analytics.js
+++ b/functions/analytics.js
@@ -1,0 +1,61 @@
+const functions = require('firebase-functions');
+const { BigQuery } = require('@google-cloud/bigquery');
+const bigquery = new BigQuery();
+
+exports.totalDownloads = functions
+  .region('europe-west1')
+  .https.onCall(async (data, context) => {
+    if (!data?.podcastId) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'No podcast specified',
+      );
+    }
+    const { podcastId } = data;
+
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'unauthenticated',
+        'The user is not authorized.',
+      );
+    } else if (!context.auth.token.podcasts.includes(podcastId)) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'The user is not authorized to access users of this podcast.',
+      );
+    }
+
+    const datasetId = 'storageanalysis';
+    const tableId = 'episode_requests';
+
+    const query = `
+    SELECT
+      cs_object, COUNT(*) as num
+    FROM
+      \`podcast-admin.${datasetId}.${tableId}\`
+    WHERE
+      SC_STATUS = 200
+      AND CONTAINS_SUBSTR(cs_object, 'mp3')
+      AND CONTAINS_SUBSTR(cs_object, '${podcastId}')
+    group by cs_object
+    order by num desc`;
+
+    // For all options, see https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
+    const options = {
+      query: query,
+      // Location must match that of the dataset(s) referenced in the query.
+      location: 'US',
+    };
+
+    try {
+      // Run the query as a job
+      const [job] = await bigquery.createQueryJob(options);
+
+      // Wait for the query to finish
+      const [rows] = await job.getQueryResults();
+
+      return rows;
+    } catch (e) {
+      return e;
+    }
+  });

--- a/functions/index.js
+++ b/functions/index.js
@@ -61,3 +61,4 @@ exports.setCustomClaims = require('./setCustomClaims');
 exports.scheduledFirestoreExport = require('./firestoreBackups');
 
 exports.users = require('./users');
+exports.analytics = require('./analytics.js');

--- a/src/components/NavigationBar/NavigationBar.js
+++ b/src/components/NavigationBar/NavigationBar.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams, Outlet } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { signOut, onAuthStateChanged } from 'firebase/auth';
+import { functions } from '../../helpers/Firebase';
+import { httpsCallable } from 'firebase/functions';
 import {
   AppBar,
   Toolbar,
@@ -111,6 +113,19 @@ const NavigationBar = () => {
                   startIcon={<Album />}
                 >
                   {t('NavigationBar.allEpisodes')}
+                </Button>
+                <Button
+                  color="inherit"
+                  startIcon={<Album />}
+                  onClick={() => {
+                    const stats = httpsCallable(
+                      functions,
+                      'analytics-totalDownloads',
+                    );
+                    stats({ podcastId });
+                  }}
+                >
+                  Stats
                 </Button>
 
                 <Tooltip title="Podcast settings">


### PR DESCRIPTION
I am not sure if it makes sense to use BigQuery going forward. Maybe we should simply push listener logs to Firestore. What's the best practice here?